### PR TITLE
feat: add karpenter accelator labels

### DIFF
--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -43,6 +43,9 @@ module "jcloud" {
   shared_gpu_instance_type = ["g4dn.xlarge", "g4dn.2xlarge", "g4dn.4xlarge"]
   gpu_instance_type        = ["g4dn.xlarge", "g4dn.2xlarge", "g4dn.4xlarge", "g4dn.12xlarge"]
 
+  shared_gpu_node_labels = { "k8s.amazonaws.com/accelerator" = "nvidia-tesla-t4" }
+  gpu_node_labels        = { "k8s.amazonaws.com/accelerator" = "nvidia-tesla-t4" }
+
   enable_cert_manager = false
   enable_kong         = true
   enable_linkerd      = true
@@ -51,6 +54,7 @@ module "jcloud" {
   enable_gpu          = true
 
   tags = {
-    Terraform = "true"
+    Terraform                = "true"
+    "karpenter.sh/discovery" = "${local.cluster_name}"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -331,6 +331,18 @@ variable "remote_external_dns_role" {
   default     = ""
 }
 
+variable "shared_gpu_node_labels" {
+  description = "Karpenter accelerator type for shared GPU"
+  type        = map(any)
+  default     = {}
+}
+
+variable "gpu_node_labels" {
+  description = "Karpenter accelerator type for GPU"
+  type        = map(any)
+  default     = {}
+}
+
 # Cert manager
 
 variable "certs" {


### PR DESCRIPTION
### Description

What is this PR about?

add labels to karpenter default gpu/gpu-shared provisioners
add AntiAffinity and topologySpreadConstraints

### Context

why you want to apply this change/features/fix?

to provide smoother scheduling for shared gpu nodes

### Comments

Any extra information we need to know about this PR?

---



@jina-ai/team-wolf 
