### PR TITLE
chore: bump version to 0.0.2

### DIFF
--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -29,7 +29,7 @@ module "jcloud" {
   cluster_name = local.cluster_name
 
   vpc_name    = local.vpc_name
-  eks_version = "1.27"
+  eks_version = "1.28"
 
   cidr            = "10.200.0.0/20"
   azs             = ["us-east-1a", "us-east-1b", "us-east-1c"]
@@ -42,6 +42,9 @@ module "jcloud" {
 
   shared_gpu_instance_type = ["g4dn.xlarge", "g4dn.2xlarge", "g4dn.4xlarge"]
   gpu_instance_type        = ["g4dn.xlarge", "g4dn.2xlarge", "g4dn.4xlarge", "g4dn.12xlarge"]
+  standard_instance_type   = ["t3a.medium", "t3a.small"]
+  system_instance_type     = ["t3a.medium"]
+
 
   shared_gpu_node_labels = { "k8s.amazonaws.com/accelerator" = "nvidia-tesla-t4" }
   gpu_node_labels        = { "k8s.amazonaws.com/accelerator" = "nvidia-tesla-t4" }

--- a/karpenter.tf
+++ b/karpenter.tf
@@ -96,9 +96,6 @@ resource "kubectl_manifest" "karpenter_provisioner" {
       - key: karpenter.k8s.aws/instance-size
         operator: NotIn
         values:
-        - nano
-        - micro
-        - small
         - 8xlarge
         - 12xlarge
         - 16xlarge
@@ -152,9 +149,6 @@ resource "kubectl_manifest" "karpenter_provisioner_system" {
       - key: karpenter.k8s.aws/instance-size
         operator: NotIn
         values:
-        - nano
-        - micro
-        - small
         - 8xlarge
         - 12xlarge
         - 16xlarge
@@ -208,9 +202,6 @@ resource "kubectl_manifest" "karpenter_provisioner_privileged" {
       - key: karpenter.k8s.aws/instance-size
         operator: NotIn
         values:
-        - nano
-        - micro
-        - small
         - 8xlarge
         - 12xlarge
         - 16xlarge

--- a/variables.tf
+++ b/variables.tf
@@ -207,6 +207,18 @@ variable "enable_karpenter" {
   default     = false
 }
 
+variable "standard_instance_type" {
+  description = "A list of EC2 instance type for stardard usage"
+  type        = list(string)
+  default     = ["t3.medium", "t3.large", "t3.xlarge"]
+}
+
+variable "system_instance_type" {
+  description = "A list of EC2 instance type for system usage"
+  type        = list(string)
+  default     = ["t3.medium", "t3.large", "t3.xlarge"]
+}
+
 variable "shared_gpu_instance_type" {
   description = "A list of EC2 instance type for shared GPU usage"
   type        = list(string)


### PR DESCRIPTION
### Description

What is this PR about?

- bump example eks version to 1.28
- allow custom instance type for karpenter default provisioners

### Context

why you want to apply this change/features/fix?

- bump example eks version to 1.28
- allow custom instance type for karpenter default provisioners

### Comments

Any extra information we need to know about this PR?

---



@jina-ai/team-wolf 
